### PR TITLE
Initialized plugin in CombatDirector

### DIFF
--- a/PerfectedLoop.cs
+++ b/PerfectedLoop.cs
@@ -1,15 +1,16 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using BepInEx;
-using R2API;
-using R2API.Utils;
+using BepInEx.Logging;
+using HarmonyLib;
 using RoR2;
+using R2API.Utils;
 
 namespace Arimah
 {
     [BepInDependency("com.bepis.r2api")]
-    [BepInPlugin("com.arimah.PerfectedLoop", "PerfectedLoop", "1.2.0")]
+    [BepInPlugin("com.arimah.PerfectedLoop", "PerfectedLoop", "1.2.1")]
     [NetworkCompatibility(CompatibilityLevel.NoNeedForSync, VersionStrictness.DifferentModVersionsAreOk)]
-    [R2APISubmoduleDependency(nameof(EliteAPI))]
     public class PerfectedLoop : BaseUnityPlugin
     {
         /// <summary>
@@ -17,26 +18,59 @@ namespace Arimah
         /// </summary>
         private const int VanillaLoopEliteTier = 3;
 
+        private static bool hasRun = false;
+
+        private static ManualLogSource instanceLogger;
+
         public void Awake()
-		{
-            var eliteTiers = EliteAPI.GetCombatDirectorEliteTiers();
-            // Find the elite tier that contains Poison (Malachite) and Haunted (Celestine).
-            // This tier is used after looping.
-            var loopEliteTier = eliteTiers.FirstOrDefault(tier =>
-                tier.eliteTypes.Contains(RoR2Content.Elites.Poison) &&
-                tier.eliteTypes.Contains(RoR2Content.Elites.Haunted)
-            );
+        {
+            // This is ugly
+            instanceLogger = Logger;
 
-            if (loopEliteTier == null)
-			{
-                Logger.LogDebug("Loop elites not found through search; falling back to vanilla index");
-                loopEliteTier = eliteTiers[VanillaLoopEliteTier];
-			}
+            new Harmony("com.arimah.PerfectedLoop").PatchAll(typeof(PerfectedLoop));
+        }
 
-            loopEliteTier.eliteTypes = loopEliteTier.eliteTypes.Concat(new[] {
-                RoR2Content.Elites.Lunar
-            }).ToArray();
-            Logger.LogMessage("Perfected elites should now appear after looping");
+        [HarmonyPatch(typeof(CombatDirector), "ResetEliteType")]
+        [HarmonyPrefix]
+        public static void CombatDirector_ResetEliteType(CombatDirector.EliteTierDef[] ___eliteTiers)
+        {
+            if (hasRun)
+            {
+                return;
+            }
+            hasRun = true;
+
+            try
+            {
+                var malachite = RoR2Content.Elites.Poison.eliteIndex;
+                var celestine = RoR2Content.Elites.Haunted.eliteIndex;
+
+                // Find the elite tier that contains Poison (Malachite) and Haunted (Celestine).
+                // This tier is used after looping.
+                var loopEliteTier = ___eliteTiers.FirstOrDefault(tier =>
+                    2 == tier.eliteTypes.Count(t =>
+                        t != null && (
+                            t.eliteIndex == malachite ||
+                            t.eliteIndex == celestine
+                        )
+                    )
+                );
+
+                if (loopEliteTier == null)
+                {
+                    instanceLogger?.LogDebug("Loop elites not found through search; falling back to vanilla index");
+                    loopEliteTier = ___eliteTiers[VanillaLoopEliteTier];
+                }
+
+                loopEliteTier.eliteTypes = loopEliteTier.eliteTypes.Concat(new[] {
+                    RoR2Content.Elites.Lunar
+                }).ToArray();
+                instanceLogger?.LogMessage("Perfected elites should now appear after looping");
+            }
+            catch (Exception e)
+            {
+                instanceLogger?.LogError(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Recent changes in Risk of Rain 2 seem to have altered the way content is loaded. If we access `CombatDirector` data through `EliteAPI` too early, then things like elite types simply will not be available; everything under `RoR2Content.Elites` is null. Worse, using `EliteAPI` forces the combat director to be initialized immediately (`CombatDirector.Init()` is called early), and then *every* elite tier gets null, and no elites can ever spawn.

Patching `CombatDirector.Init()` is unreliable, as it can be called during plugin loading by mods that use `EliteAPI`. Mod order can then break this mod by simply not calling `CombatDirector.Init()` too early. Instead I patch `ResetEliteType()`, which is called before each monster wave to select an elite tier, and that seems to work much more reliably (in addition to being called as *late* as possible, when assets are guaranteed to have been loaded).

Bonus: normalized indentation! No mixed tabs and spaces, thank goodness.

Fixes #1 